### PR TITLE
Fix incompatibility with PWG Stuffs

### DIFF
--- a/js/modus.async.js
+++ b/js/modus.async.js
@@ -1,5 +1,5 @@
 $("#albumActionsSwitcher").click( function() {
-	var box = $(".categoryActions");
+	var box = $(this).siblings(".categoryActions");
 	if (box.is(":visible")) {
 		box.css("display", ""); // remove inline css in case browser resizes larger
 	}


### PR DESCRIPTION
The modus theme displays a "..." link on mobile devices, which display a
list of actions by clicking on it.
The JS code assumes that there is only one .categoryActions element in
the body. If the user is logged in as administrator, and 'stuffs'  have
been added to the page, the selector is wrong: it will return more than 1
element.

This patch takes care of selecting the .categoryActions element next to the
link.